### PR TITLE
feat: adiciona entidade Product com validações e campos de auditoria

### DIFF
--- a/pricewiseapi/src/main/java/br/com/marcos/pricewiseapi/model/Product.java
+++ b/pricewiseapi/src/main/java/br/com/marcos/pricewiseapi/model/Product.java
@@ -1,0 +1,57 @@
+package br.com.marcos.pricewiseapi.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "products", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_product_name_normalized", columnNames = "name")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Size(min = 3, max = 100)
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Size(max = 300)
+    @Column(length = 300)
+    private String description;
+
+    @NotNull
+    @Min(0)
+    @Max(999_999)
+    @Column(nullable = false)
+    private Integer stock;
+
+    @NotNull
+    @DecimalMin("0.01")
+    @Digits(integer = 8, fraction = 2)
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal price;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @UpdateTimestamp
+    private OffsetDateTime updatedAt;
+
+    private OffsetDateTime deletedAt;
+
+}


### PR DESCRIPTION
Esta PR cria a classe Product com mapeamento JPA, validações Bean Validation e campos de auditoria (createdAt, updatedAt, deletedAt).
- Anotações de validação para nome, descrição, preço e estoque
- Normalização futura prevista para o campo name no service
- Tabela configurada com constraint de unicidade no nome
Esta entidade será base para o fluxo de criação e uso de cupons de desconto
