### PR TITLE
feat: implementa endpoint POST /coupons com validação e persistência

### DIFF
--- a/pricewiseapi/src/main/java/br/com/marcos/pricewiseapi/controller/CouponController.java
+++ b/pricewiseapi/src/main/java/br/com/marcos/pricewiseapi/controller/CouponController.java
@@ -1,0 +1,27 @@
+package br.com.marcos.pricewiseapi.controller;
+
+import br.com.marcos.pricewiseapi.dto.CreateCouponDTO;
+import br.com.marcos.pricewiseapi.dto.CouponResponseDTO;
+import br.com.marcos.pricewiseapi.service.CouponService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/v1/coupons")
+@RequiredArgsConstructor
+public class CouponController {
+
+    private final CouponService couponService;
+
+    @PostMapping
+    public ResponseEntity<CouponResponseDTO> create(@RequestBody @Valid CreateCouponDTO dto) {
+        CouponResponseDTO created = couponService.create(dto);
+        return ResponseEntity
+                .created(URI.create("/api/v1/coupons/" + created.getId()))
+                .body(created);
+    }
+}

--- a/pricewiseapi/src/main/java/br/com/marcos/pricewiseapi/dto/CouponResponseDTO.java
+++ b/pricewiseapi/src/main/java/br/com/marcos/pricewiseapi/dto/CouponResponseDTO.java
@@ -1,0 +1,18 @@
+package br.com.marcos.pricewiseapi.dto;
+
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CouponResponseDTO {
+    private Long id;
+    private String code;
+    private String discountType;
+    private BigDecimal discountValue;
+    private LocalDate expirationDate;
+}

--- a/pricewiseapi/src/main/java/br/com/marcos/pricewiseapi/dto/CreateCouponDTO.java
+++ b/pricewiseapi/src/main/java/br/com/marcos/pricewiseapi/dto/CreateCouponDTO.java
@@ -1,0 +1,29 @@
+package br.com.marcos.pricewiseapi.dto;
+
+import br.com.marcos.pricewiseapi.model.DiscountType;
+import jakarta.validation.constraints.*;
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateCouponDTO {
+
+    @NotBlank
+    private String code;
+
+    @NotNull
+    private DiscountType discountType;
+
+    @NotNull
+    @DecimalMin(value = "0.01")
+    private BigDecimal discountValue;
+
+    @NotNull
+    @Future
+    private LocalDate expirationDate;
+}

--- a/pricewiseapi/src/main/java/br/com/marcos/pricewiseapi/model/Coupon.java
+++ b/pricewiseapi/src/main/java/br/com/marcos/pricewiseapi/model/Coupon.java
@@ -1,0 +1,32 @@
+package br.com.marcos.pricewiseapi.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Coupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String code;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DiscountType discountType;
+
+    @Column(nullable = false)
+    private BigDecimal discountValue;
+
+    @Column(nullable = false)
+    private LocalDate expirationDate;
+}

--- a/pricewiseapi/src/main/java/br/com/marcos/pricewiseapi/model/DiscountType.java
+++ b/pricewiseapi/src/main/java/br/com/marcos/pricewiseapi/model/DiscountType.java
@@ -1,0 +1,6 @@
+package br.com.marcos.pricewiseapi.model;
+
+public enum DiscountType {
+    PERCENTAGE,
+    FIXED
+}

--- a/pricewiseapi/src/main/java/br/com/marcos/pricewiseapi/repository/CouponRepository.java
+++ b/pricewiseapi/src/main/java/br/com/marcos/pricewiseapi/repository/CouponRepository.java
@@ -1,0 +1,10 @@
+package br.com.marcos.pricewiseapi.repository;
+
+import br.com.marcos.pricewiseapi.model.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+    Optional<Coupon> findByCodeIgnoreCase(String code);
+}

--- a/pricewiseapi/src/main/java/br/com/marcos/pricewiseapi/service/CouponService.java
+++ b/pricewiseapi/src/main/java/br/com/marcos/pricewiseapi/service/CouponService.java
@@ -1,0 +1,42 @@
+package br.com.marcos.pricewiseapi.service;
+
+import br.com.marcos.pricewiseapi.dto.CreateCouponDTO;
+import br.com.marcos.pricewiseapi.dto.CouponResponseDTO;
+import br.com.marcos.pricewiseapi.model.Coupon;
+import br.com.marcos.pricewiseapi.repository.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+
+    public CouponResponseDTO create(CreateCouponDTO dto) {
+        couponRepository.findByCodeIgnoreCase(dto.getCode()).ifPresent(c -> {
+            throw new IllegalArgumentException("Já existe um cupom com o código informado.");
+        });
+
+        if (dto.getExpirationDate().isBefore(LocalDate.now())) {
+            throw new IllegalArgumentException("A data de expiração precisa ser futura.");
+        }
+
+        Coupon coupon = couponRepository.save(Coupon.builder()
+                .code(dto.getCode())
+                .discountType(dto.getDiscountType())
+                .discountValue(dto.getDiscountValue())
+                .expirationDate(dto.getExpirationDate())
+                .build());
+
+        return CouponResponseDTO.builder()
+                .id(coupon.getId())
+                .code(coupon.getCode())
+                .discountType(coupon.getDiscountType().name())
+                .discountValue(coupon.getDiscountValue())
+                .expirationDate(coupon.getExpirationDate())
+                .build();
+    }
+}


### PR DESCRIPTION
Esta PR adiciona o cadastro de cupons à API:
- Entidade Coupon com campos e enum DiscountType
- DTOs para criação e resposta
- Validações de código duplicado e expiração
- Endpoint POST /coupons com retorno 201 Created
Base sólida para aplicar cupons nos produtos futuramente.



